### PR TITLE
Reset para autocomplete

### DIFF
--- a/primefaces-test/src/main/java/org/primefaces/test/autocomplete/AutoCompleteBean.java
+++ b/primefaces-test/src/main/java/org/primefaces/test/autocomplete/AutoCompleteBean.java
@@ -19,15 +19,21 @@ public class AutoCompleteBean implements Serializable {
 	private String texto;
 	
 	public List<String> complete(String in) {
+		System.out.println("Complete: " + in);
+		
 		if (in == null || in.trim().isEmpty()) {
+			texto = null;
 			return Collections.emptyList();
 		}
 		
-		System.out.println(in);
 		return new ArrayList<>(Arrays.asList("0", "1", "2", in));
 	}
 	
 	public void itemSelect(SelectEvent	evento) {
+		if (evento == null) {
+			return;
+		}
+		
 		System.out.println("itemSelect: " + evento.getObject());
 	}
 }

--- a/primefaces-test/src/main/webapp/autocomplete.xhtml
+++ b/primefaces-test/src/main/webapp/autocomplete.xhtml
@@ -13,15 +13,19 @@
 		<h:form id="form">
 		
 			<h:panelGroup>
-				<h:outputText value="Opção:" id="campo" />
+				<h:outputText value="Opção:" id="campo" style="display:block" />
 				<p:autoComplete 
+					minQueryLength="0" 
 					id="textoAutoComplete" 
 					value="#{autoCompleteBean.texto}" 
 					completeMethod="#{autoCompleteBean.complete}">
 					
-					<p:ajax event="itemSelect" listener="#{autoCompleteBean.itemSelect}" />
+					<p:ajax event="itemSelect" listener="#{autoCompleteBean.itemSelect}" process="@this" update="@form" />
+					<p:ajax process="@this" update="@form" />
 				</p:autoComplete>
 			</h:panelGroup>
+			
+			<h:outputText value="#{autoCompleteBean.texto}" />
 				
 		</h:form>
 	</h:body>

--- a/primefaces-test/src/test/java/org/primefaces/test/autocomplete/AutoCompleteBeanTeste.java
+++ b/primefaces-test/src/test/java/org/primefaces/test/autocomplete/AutoCompleteBeanTeste.java
@@ -1,24 +1,28 @@
 package org.primefaces.test.autocomplete;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.primefaces.event.SelectEvent;
 import org.primefaces.test.util.ParameterizedNameDefaultTest;
 
 @DisplayName("AutoComplete Bean")
-@ExtendWith(MockitoExtension.class)
 class AutoCompleteBeanTeste {
 	
-	@InjectMocks
 	private AutoCompleteBean bean;
+	
+	@BeforeEach
+	void setUp() {
+		bean = new AutoCompleteBean();
+		bean.setTexto("Texto");
+	}
 	
 	@ParameterizedNameDefaultTest
 	@NullAndEmptySource
@@ -26,6 +30,7 @@ class AutoCompleteBeanTeste {
 	@DisplayName("Complete vazio.")
 	void completeVazio(String value) {
 		assertTrue(bean.complete(value).isEmpty());
+		assertNull(bean.getTexto());
 	}
 	
 	@ParameterizedNameDefaultTest
@@ -33,5 +38,12 @@ class AutoCompleteBeanTeste {
 	@DisplayName("Complete.")
 	void complete(String value) {
 		assertEquals(Arrays.asList("0", "1", "2", value), bean.complete(value));
+	}
+	
+	@ParameterizedTest(name = "Evento nulo.")
+	@NullSource
+	@DisplayName("ItemSelect com evento nulo.")
+	void itemSelectComEventoNulo(SelectEvent	evento) {
+		assertDoesNotThrow(() -> bean.itemSelect(evento));
 	}
 }


### PR DESCRIPTION
Considerando a não seleção para o componente `p:autoComplete`.

> Referência:
https://stackoverflow.com/questions/9877967/reset-value-to-null-in-primefaces-autocomplete-event